### PR TITLE
Avoid forcing 'become: True' on every role in the playbook, fixes redhat-sap/sap-hostagent#14, fixes redhat-sap/sap-hostagent#6

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The upstream version of this role can be found [here](https://github.com/linux-s
 ```yaml
     - hosts: servers
       roles:
-      - role: sap-hostagent
+      - { role: sap-hostagent, become: yes }
 ```
 
 ## Example Inventory

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,8 +11,5 @@ sap_hostagent_agent_tmp_directory: "/tmp/hostagent"
 # Remove the temporary directory after the installation has been done
 sap_hostagent_clean_tmp_directory: false
 
-# This role must be run as ROOT user
-ansible_become: true
-
 # SSL Variables
 sap_hostagent_config_ssl: False


### PR DESCRIPTION
Avoid forcing 'become: True' on every role in the playbook. Some tasks might require less priviledges like running uri module on AWX/Tower